### PR TITLE
Implemented ability to plan multiple dates and cancel all plans for specific maintenance request

### DIFF
--- a/E3_BarrocIntens/E3_BarrocIntens/Data/Classes/MaintenanceRequest.cs
+++ b/E3_BarrocIntens/E3_BarrocIntens/Data/Classes/MaintenanceRequest.cs
@@ -14,7 +14,7 @@ namespace E3_BarrocIntens.Data.Classes
         public Product Product { get; set; }
         public string Description { get; set; }
         public DateTime RequestedDateTime { get; set; }
-        public DateTime? PlannedDateTime { get; set; }
+        public List<DateTime> PlannedDateTimes { get; set; } = new List<DateTime>();
         public int? UserId { get; set; }
         public User? User { get; set; }
 

--- a/E3_BarrocIntens/E3_BarrocIntens/MaintenanceDashboard.xaml.cs
+++ b/E3_BarrocIntens/E3_BarrocIntens/MaintenanceDashboard.xaml.cs
@@ -28,10 +28,13 @@ namespace E3_BarrocIntens
                 using (var db = new AppDbContext())
                 {
                     plannedDates = db.maintenanceRequests
-                        .GroupBy(mr => mr.PlannedDateTime.Value.Date) // Group by date to handle duplicates
+                        .ToList() // Fetch all MaintenanceRequests from the database to the client
+                        .Where(mr => mr.PlannedDateTimes != null) // Ensure PlannedDateTimes is not null
+                        .SelectMany(mr => mr.PlannedDateTimes, (mr, date) => date.Date) // Flatten the collection and select only the date
+                        .GroupBy(date => date) // Group by date (ignoring time)
                         .ToDictionary(
-                            group => group.Key,                          // Use the date as the key
-                            group => new SolidColorBrush(Colors.Yellow)  // Assign a color to the date
+                            group => group.Key,                         // Use the date as the key
+                            group => new SolidColorBrush(Colors.Yellow) // Assign a color to the date
                         );
                 }
             }

--- a/E3_BarrocIntens/E3_BarrocIntens/PlanRequestDashboard.xaml
+++ b/E3_BarrocIntens/E3_BarrocIntens/PlanRequestDashboard.xaml
@@ -8,10 +8,13 @@
     xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
     mc:Ignorable="d"
     Background="{ThemeResource ApplicationPageBackgroundThemeBrush}">
+
     
     <ScrollViewer>
         <Grid HorizontalAlignment="Center" VerticalAlignment="Center">
             <Grid.RowDefinitions>
+                <RowDefinition Height="Auto"/>
+                <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
                 <RowDefinition Height="Auto"/>
@@ -22,8 +25,25 @@
             <TextBlock Text="Plan a maintenance request" FontSize="30" Margin="10" Grid.Row="1"/>
             <TextBlock Text="Date: " FontSize="25" Margin="10" Grid.Row="2" x:Name="dateTbl"/>
             <ComboBox DisplayMemberPath="Description" FontSize="20" Margin="10" Grid.Row="3" x:Name="maintenanceCb" Width="500"/>
-            <Button Content="Plan for this date" FontSize="25" Margin="10" x:Name="planDateBtn" Click="planDateBtn_Click" Grid.Row="4"/>
+            <ToggleSwitch Header="Repeat?" FontSize="25" x:Name="repeatSwitch" Toggled="repeatSwitch_Toggled" Grid.Row="4" Margin="10" OnContent="Yes" OffContent="No"/>
+            <StackPanel Spacing="20" Grid.Row="5" Margin="10" BorderBrush="Black" BorderThickness="2" Padding="10" x:Name="repeatStp" Visibility="Collapsed">
+                <StackPanel Orientation="Horizontal" Spacing="10">
+                    <TextBlock Text="Repeat every" FontSize="25"/>
+                    <ComboBox x:Name="repeatCb" FontSize="20" Width="100" IsEditable="True">
+                        <ComboBoxItem Content="1"/>
+                        <ComboBoxItem Content="7"/>
+                        <ComboBoxItem Content="14"/>
+                        <ComboBoxItem Content="30"/>
+                    </ComboBox>
+                    <TextBlock Text="days" FontSize="25"/>
+                </StackPanel>
+                <StackPanel Spacing="10" Orientation="Horizontal">
+                    <TextBlock Text="Repeat until" FontSize="25"/>
+                    <CalendarDatePicker x:Name="repeatUntilDp" FontSize="20"/>
+                </StackPanel>
+            </StackPanel>
+
+            <Button Content="Plan for this date" FontSize="25" Margin="10" x:Name="planDateBtn" Click="planDateBtn_Click" Grid.Row="6"/>
         </Grid>
     </ScrollViewer>
-
 </Page>

--- a/E3_BarrocIntens/E3_BarrocIntens/RescheduleRequestDashboard.xaml.cs
+++ b/E3_BarrocIntens/E3_BarrocIntens/RescheduleRequestDashboard.xaml.cs
@@ -36,12 +36,11 @@ namespace E3_BarrocIntens
         {
             base.OnNavigatedTo(e);
             maintenanceRequest = (MaintenanceRequest)e.Parameter;
-            previousDateTime = maintenanceRequest.PlannedDateTime.Value;
+            previousDateTime = maintenanceRequest.PlannedDateTimes.FirstOrDefault(); // Get the first planned date
 
             requestProduct.Text = maintenanceRequest.Product.Title;
             requestDescription.Text = maintenanceRequest.Description;
-            requestDate.Date = maintenanceRequest.PlannedDateTime.Value;
-
+            requestDate.Date = previousDateTime;
         }
 
         private void backBtn_Click(object sender, RoutedEventArgs e)
@@ -53,7 +52,10 @@ namespace E3_BarrocIntens
         {
             using (var db = new AppDbContext())
             {
-                maintenanceRequest.PlannedDateTime = requestDate.Date.DateTime;
+                // Clear existing planned dates and set the new one
+                maintenanceRequest.PlannedDateTimes.Clear();
+                maintenanceRequest.PlannedDateTimes.Add(requestDate.Date.DateTime);
+
                 db.maintenanceRequests.Update(maintenanceRequest);
                 db.SaveChanges();
             }

--- a/E3_BarrocIntens/E3_BarrocIntens/ViewDateDashboard.xaml
+++ b/E3_BarrocIntens/E3_BarrocIntens/ViewDateDashboard.xaml
@@ -45,6 +45,7 @@
                                 <StackPanel Orientation="Horizontal" Spacing="25">
                                     <Button Background="Blue" Content="Reschedule" x:Name="editBtn" Click="editBtn_Click" Foreground="White" CommandParameter="{Binding}"/>
                                     <Button Background="Red" Content="Cancel" x:Name="deleteBtn" Click="deleteBtn_Click" Foreground="White" CommandParameter="{Binding}"/>
+                                    <Button Background="DarkOrange" Content="Cancel All" x:Name="deleteAll" Click="deleteAll_Click" Foreground="White" CommandParameter="{Binding}"/>
                                 </StackPanel>
                             </StackPanel>
                         </DataTemplate>

--- a/E3_BarrocIntens/E3_BarrocIntens/ViewDateDashboard.xaml.cs
+++ b/E3_BarrocIntens/E3_BarrocIntens/ViewDateDashboard.xaml.cs
@@ -47,9 +47,14 @@ namespace E3_BarrocIntens
                 planningLv.ItemsSource = db.maintenanceRequests
                     .Include(mr => mr.Product)
                     .Include(mr => mr.User)
-                    .Where(mr => mr.PlannedDateTime.Value.Date == selectedDate.Date);
+                    .Where(mr => mr.PlannedDateTimes != null) // Ensure PlannedDateTimes is not null
+                    .AsEnumerable() // Switch to client-side evaluation
+                    .Where(mr => mr.PlannedDateTimes.Any(date => date.Date == selectedDate.Date)) // Filter in-memory
+                    .ToList();
             }
+
         }
+
         private void editBtn_Click(object sender, RoutedEventArgs e)
         {
             MaintenanceRequest maintenanceRequest = (sender as Button).CommandParameter as MaintenanceRequest;
@@ -59,9 +64,12 @@ namespace E3_BarrocIntens
         private void deleteBtn_Click(object sender, RoutedEventArgs e)
         {
             MaintenanceRequest maintenanceRequest = (sender as Button).CommandParameter as MaintenanceRequest;
+
             using (var db = new AppDbContext())
             {
-                maintenanceRequest.PlannedDateTime = null;
+                // Remove the selected date from the list of planned dates
+                maintenanceRequest.PlannedDateTimes.Remove(selectedDate);
+
                 db.Update(maintenanceRequest);
                 db.SaveChanges();
             }
@@ -76,6 +84,19 @@ namespace E3_BarrocIntens
         private void backBtn_Click(object sender, RoutedEventArgs e)
         {
             this.Frame.Navigate(typeof(MaintenanceDashboard));
+        }
+
+        private void deleteAll_Click(object sender, RoutedEventArgs e)
+        {
+            MaintenanceRequest maintenanceRequest = (sender as Button).CommandParameter as MaintenanceRequest;
+
+            using (var db = new AppDbContext())
+            {
+                maintenanceRequest.PlannedDateTimes.Clear();
+                db.Update(maintenanceRequest);
+                db.SaveChanges();
+            }
+            refreshItems();
         }
     }
 }


### PR DESCRIPTION
The Maintenance request now has a many to one relation with dates, making it possible to plan multiple dates when using the repeat function.

There is also the ability to cancell all the planned requests at once, with a new button.